### PR TITLE
Re-add GitHub action for docs deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Deploy Sphinx documentation to Pages
+
+on:
+  push:
+    branches: [main] # branch to trigger deployment
+
+jobs:
+  pages:
+    runs-on: ubuntu-20.04
+    steps:
+    - id: deployment
+      uses: sphinx-notes/pages@v3
+      with:
+        publish: false
+        documentation_path: ./docs/source
+    - uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ${{ steps.deployment.outputs.artifact }}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+sphinx 
+sphinx-autoapi 
+sphinx-rtd-theme 
+myst-parser 
+furo


### PR DESCRIPTION
## Description

Using Sphinx action from https://github.com/marketplace/actions/sphinx-to-github-pages to deploy Arsenal docs to GitHub Pages.

https://mitre-atlas.github.io/arsenal/
