### PR TITLE
Updating link to new docs URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Arsenal is a plugin developed for adversary emulation of AI-enabled systems. Thi
 
 [`Read the full documentation`](https://mitre-atlas.github.io/arsenal/intro.html#arsenal)
 
-For ml-attack-staging and ml-model-access abilities (see list below), additional information and [`examples`](https://advml.pages.mitre.org/arsenal/adversary.html#adversary-arsenal) on using these abilities are detailed in the arsenal/docs/ folder.
+For ml-attack-staging and ml-model-access abilities (see list below), additional information and [`examples`](https://mitre-atlas.github.io/arsenal/adversary.html#adversary-arsenal) on using these abilities are detailed in the arsenal/docs/ folder.
 
 
 *JUNE 2023 included abilities:*


### PR DESCRIPTION
## Description

The link to the `examples` page in the Arsenal docs was broken in the README. This change updates the link to the new URL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually tested. The updated link was visited in a rendered version of the Markdown, and went to the correct page.